### PR TITLE
Fix build and runtime errors with Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apk add --no-cache \
     build-base \
     git \
     openssl \
-    python \
+    python3 \
     py-pip
 
 WORKDIR /opt/cartesi

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN yarn install --ignore-scripts
 
 
 # Runtime image
-FROM debian:buster-slim as runtime
+FROM debian:bullseye-slim as runtime
 
 ENV BASE /opt/cartesi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.44 as build
+FROM rust:1.56 as build
 
 ENV BASE /opt/cartesi
 RUN \

--- a/deployer/Dockerfile
+++ b/deployer/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache \
     build-base \
     git \
     openssl \
-    python \
+    python3 \
 #     python-dev \
     py-pip
 


### PR DESCRIPTION
This PR fixes two build errors and a runtime error that I encountered while following the steps in the README.

First, some rust code was failing to compile with Rust 1.44. Updating to Rust 1.56 fixed the problem. The error was:

```
error[E0658]: use of unstable library feature 'str_strip': newly added
  --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/impl-serde-0.3.2/src/serialize.rs:97:24
   |
97 |     let (v, stripped) = v.strip_prefix("0x").map_or((v, false), |v| (v, true));
   |                           ^^^^^^^^^^^^
   |
   = note: see issue #67302 <rust-lang/rust#67302> for more information
```

Next, the Alpine images were failing to build because of the removal of the `python` package (replaced with `python3`). The error was:

```
ERROR: unable to select packages:
  python (no such package):
    required by: world[python]
```

Finally, the build succeeded, but during runtime the `ACCOUNT_ADDRESS` environment variable wasn't being set because wagyu couldn't find a version of GCC it was happy with. Updating Debian to bullseye fixed the error. The error was:

```
wagyu: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by wagyu)
```

With these changes applied, I was able to run all the examples in the README.