### PR TITLE
Update Descartes.sol

### DIFF
--- a/contracts/Descartes.sol
+++ b/contracts/Descartes.sol
@@ -1195,7 +1195,7 @@ contract Descartes is InstantiatorImpl, Decorated, DescartesInterface {
     modifier onlyByParty(uint256 _index) {
         DescartesCtx storage i = instance[_index];
         require(
-            i.parties[msg.sender].isParty,
+            i.parties[msg.sender].isParty || i.partiesArray.length == 1,
             "The sender is not party to this instance"
         );
         _;


### PR DESCRIPTION
allow "fully decentralized challenging": if only one party (= the claimer) is specified, anyone can challenge. At first glance, this would not interfere with the "confirm()" function because the check in line 500 always fails if called, although I guess the one should more explicitly disable this function in this case. Not sure how if anything else would break though. Just wanted to start a discussion